### PR TITLE
refactor: use scoped registries

### DIFF
--- a/src/LitHn.js
+++ b/src/LitHn.js
@@ -1,9 +1,18 @@
+import { ScopedRegistryHost } from "@lit-labs/scoped-registry-mixin";
 import { LitElement, html } from "lit";
-import "./hn-footer/hn-footer.js";
-import "./hn-header/hn-header.js";
-import "./hn-topstories/hn-topstories.js";
+import { HnFooter } from "./hn-footer/HnFooter.js";
+import { HnHeader } from "./hn-header/HnHeader.js";
+import { HnTopstories } from "./hn-topstories/HnTopstories.js";
 
-export class LitHn extends LitElement {
+export class LitHn extends ScopedRegistryHost(LitElement) {
+  static get elementDefinitions() {
+    return {
+      "hn-footer": HnFooter,
+      "hn-header": HnHeader,
+      "hn-topstories": HnTopstories,
+    };
+  }
+
   // eslint-disable-next-line class-methods-use-this
   render() {
     return html`

--- a/src/api/topStories.js
+++ b/src/api/topStories.js
@@ -1,9 +1,9 @@
 import { Task } from "@lit-labs/task";
-import { ReactiveControllerHost } from "lit";
+import { ReactiveElement } from "lit";
 import { apiUrl } from "./config/index.js";
 
 /**
- * @param {ReactiveControllerHost} host Host element
+ * @param {ReactiveElement} host Host element
  * @returns {Task} Api task controller
  */
 export function topStories(host) {

--- a/src/hn-footer/hn-footer.js
+++ b/src/hn-footer/hn-footer.js
@@ -1,3 +1,0 @@
-import { HnFooter } from "./HnFooter.js";
-
-customElements.define("hn-footer", HnFooter);

--- a/src/hn-header/hn-header.js
+++ b/src/hn-header/hn-header.js
@@ -1,3 +1,0 @@
-import { HnHeader } from "./HnHeader.js";
-
-customElements.define("hn-header", HnHeader);

--- a/src/hn-story/HnStory.js
+++ b/src/hn-story/HnStory.js
@@ -1,13 +1,19 @@
 import { LitElement, html } from "lit";
-import { ScopedRegistryHost } from "@lit-labs/scoped-registry-mixin";
 
-export class HnStory extends ScopedRegistryHost(LitElement) {
+export class HnStory extends LitElement {
   static get properties() {
     return {
       key: {
         type: String,
       },
     };
+  }
+
+  constructor() {
+    super();
+
+    /** @type {string|undefined} */
+    this.key = undefined;
   }
 
   render() {

--- a/src/hn-story/hn-story.js
+++ b/src/hn-story/hn-story.js
@@ -1,3 +1,0 @@
-import { HnStory } from "./HnStory.js";
-
-customElements.define("hn-story", HnStory);

--- a/src/hn-topstories/HnTopstories.js
+++ b/src/hn-topstories/HnTopstories.js
@@ -1,8 +1,15 @@
 import { LitElement, html } from "lit";
 import { ScopedRegistryHost } from "@lit-labs/scoped-registry-mixin";
 import { topStories } from "../api/topStories.js";
+import { HnStory } from "../hn-story/HnStory.js";
 
 export class HnTopstories extends ScopedRegistryHost(LitElement) {
+  static get elementDefinitions() {
+    return {
+      "hn-story": HnStory,
+    };
+  }
+
   constructor() {
     super();
     this.api = topStories(this);
@@ -11,7 +18,6 @@ export class HnTopstories extends ScopedRegistryHost(LitElement) {
   render() {
     return html`
       ${this.api.render({
-        initial: () => import("../hn-story/hn-story.js"),
         pending: () => html`Loading topstories...`,
         complete: (result) => html`<ol>
           ${result.map(

--- a/src/hn-topstories/hn-topstories.js
+++ b/src/hn-topstories/hn-topstories.js
@@ -1,3 +1,0 @@
-import { HnTopstories } from "./HnTopstories.js";
-
-customElements.define("hn-topstories", HnTopstories);


### PR DESCRIPTION
# What I did

- Use the scoped registry for internal components.
- Remove unnecessary side effect files for internal components.
- Fix some types.